### PR TITLE
updates classification_and_redaction notebook with updated cli example

### DIFF
--- a/classification_and_redaction/classification_and_redaction.ipynb
+++ b/classification_and_redaction/classification_and_redaction.ipynb
@@ -2,44 +2,41 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "982f45b742050318",
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install antimatter==0.1.14 pandas pyarrow"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "982f45b742050318",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "cb491f486b1bdbdd",
+   "metadata": {},
    "outputs": [],
    "source": [
     "import antimatter\n",
     "import pandas\n",
     "import json"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "cb491f486b1bdbdd",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b560117ef20180af",
+   "metadata": {},
    "source": [
     "First thing we do is create an Antimatter domain. This can be done with the CLI, or with the python library. \n",
     "\n",
     "To make it easier to run the notebook, we'll save our credentials for the created domain and re-use them if they exist"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "b560117ef20180af"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "27eeddaaaa0be83f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# IMPORTANT: Change to your business email address to create a free account.\n",
@@ -54,112 +51,94 @@
     "    with open(\"domain_credentials.json\", \"w\") as f:\n",
     "        json.dump(amr.config(), f)\n",
     "    print (\"New domain created - check your email before proceeding\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "27eeddaaaa0be83f",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "35a80a7b64e69432",
+   "metadata": {},
    "source": [
     "If this is the first time you have run the notebook, this will have sent a confirmation email to your email address (it can take a few minutes). \n",
     "\n",
     "**Click the button in the email to activate your domain before proceeding.**\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "35a80a7b64e69432"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ae62d9c48db9e20c",
+   "metadata": {},
    "source": [
     "Now that we have an Antimatter domain, let's see how we can use Antimatter to classify some sensitive data and redact it. Let's load a parquet file that contains a mix of structured data and embedded unstructured data (a comments column)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ae62d9c48db9e20c"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "2e2ebaa56a98361a",
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = pandas.read_parquet(\"https://get.antimatter.io/data/example_data.parquet\")\n",
     "df"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "2e2ebaa56a98361a",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b35fa0b1d4f2514",
+   "metadata": {},
    "source": [
     "You can see that we have a bunch of data here that would probably be considered sensitive in some contexts. Some of it is in clearly labelled columns, which might be easy to deal with manually, but some of it is embedded within free-form text in the comments column. That's pretty common whenever you are storing data coming from users: they can (and often do) enter sensitive info that needs special handling.\n",
     "\n",
     "Let's *encapsulate* this data. A capsule is Antimatter's object format for tagged data. It stores the full set of data, as well as all the classification tags. It's encrypted, so can be stored anywhere without worrying that sensitive data might be accessible to those who can access the object. Having an intermediate file format lets you do the classification once, and then re-use multiple times. This is convenient, because classification is often fairly heavyweight.\n",
     "\n",
     "When we encapsulate, we have to specify a *write_context* that contains the configuration for which classifiers to run on the data. New domains come with a `default` write context that does no classification, and a `sensitive` write context that uses the `fast-pii` classifier to tag common PII. You can change the configuration of these write contexts or add new ones as needed, but we're going to just use `sensitive` for now."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "b35fa0b1d4f2514"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "88c9e08169108243",
+   "metadata": {},
    "outputs": [],
    "source": [
     "capsule = amr.encapsulate(df, write_context=\"sensitive\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "88c9e08169108243",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7774521d9371ceb0",
+   "metadata": {},
    "source": [
     "Once the classification is done, we can write the capsule to a file, or just use it directly to read the data. When reading data, you need to specify a `read_context` which contains the configuration for what redaction and transformation should occur on the data. New domains come with a `default` read context which does no redaction, but we will add some rules to it in a bit"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "7774521d9371ceb0"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "7838bf4e0106ece2",
+   "metadata": {},
    "outputs": [],
    "source": [
     "capsule.save(\"mycapsule.ca\")\n",
     "data = amr.load_capsule(data=capsule, read_context=\"default\").data()\n",
     "data"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "7838bf4e0106ece2",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a0eef86dec8066dc",
+   "metadata": {},
    "source": [
     "You will notice that what we got back was a Pandas dataframe. Antimatter stores some information about the shape of the data during encapsulation, and automatically presents the data in the same form when reading (in this case, a Pandas dataframe). This lets you insert Antimatter into your data pipeline without impacting any of the operations that happen after the read. You can use `.data_as()` instead of `.data()` if you'd like to read the data in a different format.\n",
     "\n",
     "So now, let's do some redaction. This is achieved by adding a rule to the read context. Rules can be fairly complex, to deal with advanced cases like reproducing permissions that existed in the original source of data, but we're going to make a simple one that just references a Tag and redacts if it exists:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "a0eef86dec8066dc"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ba29c948abe6a82c",
+   "metadata": {},
    "outputs": [],
    "source": [
     "amr.add_read_context_rules('default', antimatter.ReadContextRuleBuilder()\n",
@@ -167,47 +146,39 @@
     "                                          key=\"tag.antimatter.io/pii/name\",\n",
     "                                          operator=antimatter.Operator.Exists)\n",
     "                    .set_action(antimatter.Action.Redact))"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ba29c948abe6a82c",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8b833074de15cb0b",
+   "metadata": {},
    "source": [
     "Now, if we read the data again, we'll see that names have been redacted in both the name columns, but also in the comments:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "8b833074de15cb0b"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c6b0deff5eb669fc",
+   "metadata": {},
    "outputs": [],
    "source": [
     "amr.load_capsule(data=capsule, read_context=\"default\").data()"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "c6b0deff5eb669fc",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "24fbf75db6efcde8",
+   "metadata": {},
    "source": [
     "We added the rule to the `default` read context, but the purpose of read contexts is to be able to capture policy about what data can be used in which conditions. So you might have different read contexts for use cases (e.g. model training) or for different teams (e.g. fraud). Let's make a new read context for `analytics` and configure some rules to redact more of the PII in this dataset:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "24fbf75db6efcde8"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "7c49003eec5d6384",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# add a new read context\n",
@@ -230,95 +201,80 @@
     "                                          key=\"tag.antimatter.io/pii/ssn\",\n",
     "                                          operator=antimatter.Operator.Exists)\n",
     "                    .set_action(antimatter.Action.Redact))"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "7c49003eec5d6384",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8a3b66d2d9dca5a4",
+   "metadata": {},
    "source": [
     "Now, if we load the capsule again, we'll see that more of the PII has been redacted"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "8a3b66d2d9dca5a4"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "644369ce6ea0e342",
+   "metadata": {},
    "outputs": [],
    "source": [
     "amr.load_capsule(data=capsule, read_context=\"analytics\").data()"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "644369ce6ea0e342",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3e2ca75f2a001918",
+   "metadata": {},
    "source": [
     "You can see which tags are available to reference in your rules by calling `list_hooks`. The `sensitive` write context uses `fast-pii` by default:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "3e2ca75f2a001918"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1b932ee5b62848f3",
+   "metadata": {},
    "outputs": [],
    "source": [
     "amr.list_hooks()"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "1b932ee5b62848f3",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "77fa69d417d061c6",
+   "metadata": {},
    "source": [
     "One of the advantage of using Antimatter is that the policy captured in the read context is separate from your data pipeline. Often, the rules of what data is allowed to be used by whom are actually decided by different stakeholders (e.g. the security or legal teams) than the folks who are doing data cleaning and augmentation for the purposes of analytics. \n",
     "\n",
     "The read context rules can be configured by anyone who is invited to the domain, using the python libraries, the command line tool, or the web app. Let's create an API key for a colleague on the security team to configure the read contexts. For simplicity, we'll make them an `admin`:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "77fa69d417d061c6"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "187ce4e2adb16a62",
+   "metadata": {},
    "outputs": [],
    "source": [
     "apik = amr.insert_identity_provider_principal('apikey',\n",
     "    capabilities={'admin':None}, \n",
     "    principal_type=antimatter.PrincipalType.ApiKey)\n",
     "print (f\"Login with --domain-id={amr.config()['domain']} --api-key={apik['api_key']}\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "187ce4e2adb16a62",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b8630d5fe4edd072",
+   "metadata": {},
    "source": [
     "They can use the CLI (for example) to interact with the domain like this:\n",
     "\n",
     "```bash\n",
     "# get the latest Antimatter CLI:\n",
-    "$ sudo curl https://get.antimatter.io/cli/latest-macos-arm64 -o /usr/local/bin/am\n",
+    "$ sudo curl https://get.antimatter.io/cli/darwin/arm64/am -o /usr/local/bin/am\n",
     "$ sudo chmod a+x /usr/local/bin/am\n",
     "\n",
-    "$ am login --domain-id dm-xxxxxxxxxxx --api-key xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n",
+    "$ am config domain login --domain-id dm-xxxxxxxxxxx --api-key xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n",
     "$ am read-context list\n",
     "readContexts:\n",
     "- name: analytics\n",
@@ -346,49 +302,42 @@
     "--match 'exists(tag(\"tag.antimatter.io/pii/location\"))' \\\n",
     "--priority 0\n",
     "```\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "b8630d5fe4edd072"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4bc506e762230013",
+   "metadata": {},
    "source": [
     "Now, if we read the same capsule as before, we will see that addresses have been redacted. We don't need to re-encapsulate or re-materialize any datasets. For example purposes, lets read it from the file instead of using the `capsule` variable:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "4bc506e762230013"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "10dbaccdf2c7d7ea",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# we saved \"mycapsule.ca\" earlier\n",
     "amr.load_capsule(path=\"mycapsule.ca\",read_context=\"analytics\").data()"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "10dbaccdf2c7d7ea",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f1a7bec42e439cd8",
+   "metadata": {},
    "source": [
     "You can see that the addresses are now redacted too.\n",
     "\n",
     "We used a Pandas dataframe above, but you can encapsulate data of multiple different shapes. For example, even a plain string can be encapsulated by itself:"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "f1a7bec42e439cd8"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "669877a01d6c9609",
+   "metadata": {},
    "outputs": [],
    "source": [
     "string_cap = amr.encapsulate(\n",
@@ -397,41 +346,34 @@
     "    We support many shapes of data, like strings, dicts, lists of dicts, pandas dataframes, pytorch data loaders etc\n",
     "    \"\"\", write_context=\"sensitive\")\n",
     "print(amr.load_capsule(data=string_cap, read_context=\"analytics\").data())"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "669877a01d6c9609",
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "45d226c22aa13c8c",
+   "metadata": {},
    "source": [
     "For more information, please see [the docs](https://docs.antimatter.io)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "45d226c22aa13c8c"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Aside from the normal excess of metadata updates, this PR fixes the CLI download link and outdated example of `am config domain login`.